### PR TITLE
separate exit game for inflight deposits

### DIFF
--- a/contracts/DepositHandler.sol
+++ b/contracts/DepositHandler.sol
@@ -21,7 +21,7 @@ contract DepositHandler is Vault {
   );
 
   struct Deposit {
-    uint64 height;
+    uint64 time;
     uint16 color;
     address owner;
     uint256 amount;
@@ -44,11 +44,12 @@ contract DepositHandler is Vault {
     tokens[_color].addr.transferFrom(_owner, this, _amountOrTokenId);
 
     bytes32 tipHash = bridge.tipHash();
-    (,uint32 height,,) = bridge.periods(tipHash);
+    uint256 timestamp;
+    (,,, timestamp) = bridge.periods(tipHash);
 
     depositCount++;
     deposits[depositCount] = Deposit({
-      height: height,
+      time: uint32(timestamp),
       owner: _owner,
       color: _color,
       amount: _amountOrTokenId

--- a/contracts/ExitHandler.sol
+++ b/contracts/ExitHandler.sol
@@ -150,7 +150,7 @@ contract ExitHandler is DepositHandler {
       priority = (nftExitCounter << 128) | uint128(_depositId);
       nftExitCounter++;
     } else {      
-      priority = getERC20ExitPriority(uint32(now), bytes32(_depositId), 0);
+      priority = getERC20ExitPriority(uint32(deposit.time), bytes32(_depositId), 0);
     }
 
     tokens[deposit.color].insert(priority);

--- a/migrations/2_deploy.js
+++ b/migrations/2_deploy.js
@@ -63,6 +63,9 @@ module.exports = (deployer, network) => {
     data = await operatorCont.contract.initialize.getData(bridgeProxy.address, exitHandlerProxy.address, epochLength);
     const operatorProxy = await deployer.deploy(AdminableProxy, operatorCont.address, data);
 
+    await bridgeProxy.changeAdmin(bridgeProxy.address);
+    await exitHandlerProxy.changeAdmin(exitHandlerProxy.address);
+
     const bridge = Bridge.at(bridgeProxy.address);
     data = await bridge.contract.setOperator.getData(operatorProxy.address);
     await bridgeProxy.applyProposal(data);

--- a/migrations/2_deploy.js
+++ b/migrations/2_deploy.js
@@ -63,9 +63,6 @@ module.exports = (deployer, network) => {
     data = await operatorCont.contract.initialize.getData(bridgeProxy.address, exitHandlerProxy.address, epochLength);
     const operatorProxy = await deployer.deploy(AdminableProxy, operatorCont.address, data);
 
-    await bridgeProxy.changeAdmin(bridgeProxy.address);
-    await exitHandlerProxy.changeAdmin(exitHandlerProxy.address);
-
     const bridge = Bridge.at(bridgeProxy.address);
     data = await bridge.contract.setOperator.getData(operatorProxy.address);
     await bridgeProxy.applyProposal(data);

--- a/test/exitHandler.js
+++ b/test/exitHandler.js
@@ -162,6 +162,18 @@ contract('ExitHandler', (accounts) => {
 
       });
 
+      it('Should allow to exit deposit', async () => {
+        await exitHandler.startDepositExit(1);
+
+        const aliceBalanceBefore = await nativeToken.balanceOf(alice);
+
+        await exitHandler.finalizeTopExit(nativeTokenColor);
+
+        const aliceBalanceAfter = await nativeToken.balanceOf(alice);
+
+        aliceBalanceBefore.plus(depositAmount).should.be.bignumber.equal(aliceBalanceAfter);
+      });
+
       it('Should allow to exit NFT utxo', async () => {
         const period = await submitNewPeriod([nftDepositTx, nftTransferTx]);
 

--- a/test/exitHandler.js
+++ b/test/exitHandler.js
@@ -44,7 +44,7 @@ contract('ExitHandler', (accounts) => {
     let depositTx;
     let transferTx;
     const depositAmount = 100;
-    const depositId = 0;
+    const depositId = 1;
 
     // ERC721 token stuff
     let nftToken;
@@ -172,6 +172,24 @@ contract('ExitHandler', (accounts) => {
         const aliceBalanceAfter = await nativeToken.balanceOf(alice);
 
         aliceBalanceBefore.plus(depositAmount).should.be.bignumber.equal(aliceBalanceAfter);
+      });
+
+
+      it('Should allow to challenge exiting deposit', async () => {
+        await exitHandler.startDepositExit(1);
+
+        const period = await submitNewPeriod([depositTx]);
+        const one = '0x0000000000000000000000000000000000000000000000000000000000000001';
+        const proof = period.proof(depositTx);
+
+        // challenge exit and make sure exit is removed
+        let exit = await exitHandler.exits(one);
+        assert.equal(exit[2], alice);
+        
+        await exitHandler.challengeExit([], proof, 0, 0);        
+        exit = await exitHandler.exits(one);
+        // check that exit was deleted
+        assert.equal(exit[2], '0x0000000000000000000000000000000000000000');
       });
 
       it('Should allow to exit NFT utxo', async () => {


### PR DESCRIPTION
addresses https://github.com/leapdao/leap-contracts/issues/72


- [x] create startDepositExit(depositId) method for exiting inflight deposits.
- [x] enable challengeExit for deposits to challenge invalid deposit exits. 
~- [ ] define a depositInclusionTime — reasonable number of periods to wait for deposit tx to be included. It should be changeable via governance.~
- [x] make sure leap-node is working correctly with the change, picking up deposits as it should be
