### PR TITLE
merge Submission and NewHeight events into one

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -19,7 +19,6 @@ contract Bridge is Adminable {
     _;
   }
 
-  event NewHeight(uint256 height, bytes32 indexed root);
   event NewOperator(address operator);
 
   struct Period {
@@ -82,7 +81,6 @@ contract Bridge is Adminable {
       );
       tipHash = _root;
       lastParentBlock = block.number;
-      emit NewHeight(newHeight, _root);
     }
     // store the period
     Period memory newPeriod = Period({

--- a/contracts/PoaOperator.sol
+++ b/contracts/PoaOperator.sol
@@ -152,6 +152,7 @@ contract PoaOperator is Adminable {
   event Submission(
     bytes32 indexed blocksRoot,
     uint256 indexed slotId,
+    uint256 newHeight,
     address owner,
     bytes32 periodRoot
   );
@@ -202,6 +203,11 @@ contract PoaOperator is Adminable {
       lastEpochBlockHeight = newHeight;
       emit Epoch(lastCompleteEpoch);
     }
-    emit Submission(_blocksRoot, _slotId, slot.owner, hashRoot);
+    emit Submission(
+      _blocksRoot,
+      _slotId,
+      newHeight,
+      slot.owner,
+      hashRoot);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/leapdao/leap-contracts/issues/131.

Merged the two duplicate events `NewHeight` and `Submission` into a single `Submission` event.

```
event Submission(
  bytes32 indexed blocksRoot,
  uint256 indexed slotId,
  uint256 newHeight,
  address owner,
  bytes32 periodRoot
);
```