### PR TITLE
advance block and events delay added to write config

### DIFF
--- a/migrations/utils/writeConfig.js
+++ b/migrations/utils/writeConfig.js
@@ -17,6 +17,8 @@ function writeConfig({ bridgeProxy, operatorProxy, exitHandlerProxy }, network) 
   const networkData = truffleConfig.networks[network];
   const rootNetwork = `http://${networkData.host}:${networkData.port}`;
   const networkId = Math.floor(Math.random() * Math.floor(1000000000));
+  const advanceBlock = process.env.ADVANCE_BLOCK || 0;
+  const eventsDelay = process.env.EVENTS_DELAY || 0;
   const config = {
     "bridgeAddr": bridgeProxy.address,
     "operatorAddr": operatorProxy.address,
@@ -24,7 +26,9 @@ function writeConfig({ bridgeProxy, operatorProxy, exitHandlerProxy }, network) 
     "rootNetwork": rootNetwork,
     "network": network,
     "networkId": networkId,
-    "peers": []
+    "peers": [],
+    "advanceBlock": advanceBlock,
+    "eventsDelay": eventsDelay
   }
   fs.writeFile(
     "./build/nodeFiles/generatedConfig.json",

--- a/migrations/utils/writeConfig.js
+++ b/migrations/utils/writeConfig.js
@@ -17,8 +17,8 @@ function writeConfig({ bridgeProxy, operatorProxy, exitHandlerProxy }, network) 
   const networkData = truffleConfig.networks[network];
   const rootNetwork = `http://${networkData.host}:${networkData.port}`;
   const networkId = Math.floor(Math.random() * Math.floor(1000000000));
-  const advanceBlock = process.env.ADVANCE_BLOCK || 0;
-  const eventsDelay = process.env.EVENTS_DELAY || 0;
+  const bridgeDelay = process.env.BRIDGE_DELAY || 6;
+  const eventsDelay = process.env.EVENTS_DELAY || 2;
   const config = {
     "bridgeAddr": bridgeProxy.address,
     "operatorAddr": operatorProxy.address,
@@ -27,7 +27,7 @@ function writeConfig({ bridgeProxy, operatorProxy, exitHandlerProxy }, network) 
     "network": network,
     "networkId": networkId,
     "peers": [],
-    "advanceBlock": advanceBlock,
+    "bridgeDelay": bridgeDelay,
     "eventsDelay": eventsDelay
   }
   fs.writeFile(


### PR DESCRIPTION
Minor change to `writeConfig.js`: added 2 parameters - advanceBlock and eventsDelay, values taken from environment. No impact on actual deployment