### PR TITLE
more context for periods

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -86,10 +86,8 @@ contract Bridge is Adminable {
       );
       tipHash = _root;
       lastParentBlock = block.number;
+      emit NewHeight(newHeight, _root);
     }
-    // strictly speaking this event should be called "New Period"
-    // but we don't want to break interfaces for now.
-    emit NewHeight(newHeight, _root);
     // store the period
     Period memory newPeriod = Period({
       height: uint32(newHeight),

--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -25,6 +25,8 @@ contract Bridge is Adminable {
   struct Period {
     uint32 height;  // the height of last block in period
     uint32 timestamp;
+    uint32 parentBlockNumber;
+    bytes32 parentBlockHash;
   }
 
   bytes32 constant GENESIS = 0x4920616d207665727920616e6772792c20627574206974207761732066756e21;
@@ -41,7 +43,9 @@ contract Bridge is Adminable {
     // init genesis preiod
     Period memory genesisPeriod = Period({
       height: 1,
-      timestamp: uint32(block.timestamp)
+      timestamp: uint32(block.timestamp),
+      parentBlockNumber: uint32(block.number),
+      parentBlockHash: blockhash(block.number-1)
     });
     tipHash = GENESIS;
     periods[GENESIS] = genesisPeriod;
@@ -82,12 +86,14 @@ contract Bridge is Adminable {
       );
       tipHash = _root;
       lastParentBlock = block.number;
-      emit NewHeight(newHeight, _root);
     }
+    emit NewHeight(newHeight, _root);
     // store the period
     Period memory newPeriod = Period({
       height: uint32(newHeight),
-      timestamp: uint32(block.timestamp)
+      timestamp: uint32(block.timestamp),
+      parentBlockNumber: uint32(block.number),
+      parentBlockHash: blockhash(block.number-1)
     });
     periods[_root] = newPeriod;
   }

--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -23,10 +23,10 @@ contract Bridge is Adminable {
   event NewOperator(address operator);
 
   struct Period {
-    uint32 height;  // the height of last block in period
-    uint32 timestamp;
-    uint32 parentBlockNumber;
-    bytes32 parentBlockHash;
+    uint32 height;            // the height of last block in period
+    uint32 timestamp;         // the block.timestamp at submission of period
+    uint32 parentBlockNumber; // the block.number at submission of period
+    bytes32 parentBlockHash;  // the blockhash(block.number -1) at submission of period
   }
 
   bytes32 constant GENESIS = 0x4920616d207665727920616e6772792c20627574206974207761732066756e21;
@@ -87,6 +87,8 @@ contract Bridge is Adminable {
       tipHash = _root;
       lastParentBlock = block.number;
     }
+    // strictly speaking this event should be called "New Period"
+    // but we don't want to break interfaces for now.
     emit NewHeight(newHeight, _root);
     // store the period
     Period memory newPeriod = Period({

--- a/contracts/DepositHandler.sol
+++ b/contracts/DepositHandler.sol
@@ -85,7 +85,7 @@ contract DepositHandler is Vault {
 
     bytes32 tipHash = bridge.tipHash();
     uint256 timestamp;
-    (, timestamp) = bridge.periods(tipHash);
+    (, timestamp,,) = bridge.periods(tipHash);
 
     depositCount++;
     deposits[depositCount] = Deposit({

--- a/contracts/ExitHandler.sol
+++ b/contracts/ExitHandler.sol
@@ -84,11 +84,11 @@ contract ExitHandler is IExitHandler, DepositHandler {
   ) public payable {
     require(msg.value >= exitStake, "Not enough ether sent to pay for exit stake");
     uint32 timestamp;
-    (, timestamp) = bridge.periods(_proof[0]);
+    (, timestamp,,) = bridge.periods(_proof[0]);
     require(timestamp > 0, "The referenced period was not submitted to bridge");
 
     if (_youngestInputProof.length > 0) {
-      (, timestamp) = bridge.periods(_youngestInputProof[0]);
+      (, timestamp,,) = bridge.periods(_youngestInputProof[0]);
       require(timestamp > 0, "The referenced period was not submitted to bridge");
     }
 
@@ -381,7 +381,7 @@ contract ExitHandler is IExitHandler, DepositHandler {
     require(txHash == exitingTx.ins[_inputIndex].outpoint.hash, "Given output is not referenced in exiting tx");
 
     uint32 youngerInputTimestamp;
-    (,youngerInputTimestamp) = bridge.periods(_youngerInputProof[0]);
+    (,youngerInputTimestamp,,) = bridge.periods(_youngerInputProof[0]);
     require(youngerInputTimestamp > 0, "The referenced period was not submitted to bridge");
 
     require(exits[utxoId].priorityTimestamp < youngerInputTimestamp, "Challenged input should be older");

--- a/contracts/FastExitHandler.sol
+++ b/contracts/FastExitHandler.sol
@@ -28,10 +28,10 @@ contract FastExitHandler is ExitHandler {
     require(msg.value >= exitStake, "Not enough ether sent to pay for exit stake");
     Data memory data;
 
-    (,data.timestamp) = bridge.periods(_proof[0]);
+    (,data.timestamp,,) = bridge.periods(_proof[0]);
     require(data.timestamp > 0, "The referenced period was not submitted to bridge");
 
-    (, data.timestamp) = bridge.periods(_youngestInputProof[0]);
+    (, data.timestamp,,) = bridge.periods(_youngestInputProof[0]);
     require(data.timestamp > 0, "The referenced period was not submitted to bridge");
 
     // check exiting tx inclusion in the root chain block

--- a/contracts/SwapRegistry.sol
+++ b/contracts/SwapRegistry.sol
@@ -77,7 +77,7 @@ contract SwapRegistry is Adminable {
         mstore(0x20, right)
         right := keccak256(0, 0x40)
       }
-      (height ,) = bridge.periods(right);
+      (height ,,,) = bridge.periods(right);
       require(height > maxHeight, "unorderly claim");
       maxHeight = height;
       claimCount += 1;


### PR DESCRIPTION
this PR introduced block.number and blockhash of parent network into the bridge contract. this data can be used together with the period root to prove context in solEVM.