### PR TITLE
always emit new period event

### DIFF
--- a/contracts/Bridge.sol
+++ b/contracts/Bridge.sol
@@ -82,8 +82,10 @@ contract Bridge is Adminable {
       );
       tipHash = _root;
       lastParentBlock = block.number;
-      emit NewHeight(newHeight, _root);
     }
+    // strictly speaking this event should be called "New Period"
+    // but we don't want to break interfaces for now.
+    emit NewHeight(newHeight, _root);
     // store the period
     Period memory newPeriod = Period({
       height: uint32(newHeight),


### PR DESCRIPTION
this is needed so that we can monitor the submission of periods, and catch dark periods to potentially challenge them.