### PR TITLE
fix: do not specify rootNetworkId in generated config.

### DIFF
--- a/migrations/utils/writeConfig.js
+++ b/migrations/utils/writeConfig.js
@@ -24,7 +24,6 @@ function writeConfig({ bridgeProxy, operatorProxy, exitHandlerProxy }, network) 
     "operatorAddr": operatorProxy.address,
     "exitHandlerAddr": exitHandlerProxy.address,
     "rootNetwork": rootNetwork,
-    "rootNetworkId": 5777,
     "network": network,
     "networkId": networkId,
     "peers": [],


### PR DESCRIPTION
So that it can be used with the node with `--devMode` (random networkId)

Relates https://github.com/leapdao/leap-node/pull/353

Required for integration tests to work.