### PR TITLE
fix: wrong parsing of a spending condition tx

### DIFF
--- a/contracts/TxLib.sol
+++ b/contracts/TxLib.sol
@@ -192,7 +192,9 @@ library TxLib {
     Input[] memory ins = new Input[](a);
     uint256 offset = 2;
     for (uint i = 0; i < ins.length; i++) {
-      offset = parseInput(txType, _txData, i, offset, ins); // solium-disable-line arg-overflow
+      offset = parseInput(
+        i == 0 ? txType: TxType.Transfer, _txData, i, offset, ins // solium-disable-line arg-overflow
+      ); 
     }
     assembly {
         a := mload(add(0x21, _txData))

--- a/test/txLib.js
+++ b/test/txLib.js
@@ -62,8 +62,8 @@ function checkParse(rsp, txn) {
   // outputs
   for (let i = 0; i < txn.outputs.length; i++) {
     assert(equal(toInt(rsp.outs[i].value), txn.outputs[i].value));
-    assert.equal(toInt(rsp.outs[i].color), txn.outputs[i].color);
-    assert.equal(rsp.outs[i].owner, txn.outputs[i].address);
+    assert.equal(rsp.outs[i].color, txn.outputs[i].color);
+    assert.equal(rsp.outs[i].owner.toLowerCase(), txn.outputs[i].address.toLowerCase());
     assert.equal(rsp.outs[i].stateRoot, txn.outputs[i].isNST() ? txn.outputs[i].data : EMPTY); // storage root
   }
 }

--- a/test/txLib.js
+++ b/test/txLib.js
@@ -38,14 +38,14 @@ function checkParse(rsp, txn) {
   assert.equal(rsp.txType, txn.type);
   if (txn.type === Type.DEPOSIT) {
     // eslint-disable-next-line no-param-reassign
-    txn.inputs = [{prevout: {hash: fromInt(txn.options.depositId)}}];
+    txn.inputs = [{prevout: { hash: fromInt(txn.options.depositId), index: 0 }}];
   }
   assert.equal(rsp.ins.length, txn.inputs.length);
   assert.equal(rsp.outs.length, txn.outputs.length);
   // inputs
   for (let i = 0; i < txn.inputs.length; i++) {
     assert.equal(rsp.ins[i].outpoint[0], `0x${txn.inputs[i].prevout.hash.toString('hex')}`);
-    assert.equal(toInt(rsp.ins[i].outpoint[1]), i); // output position
+    assert.equal(toInt(rsp.ins[i].outpoint[1]), txn.inputs[i].prevout.index); // output position
     if (txn.type === Type.TRANSFER) {
       assert.equal(rsp.ins[i].r, `0x${txn.inputs[i].r.toString('hex')}`);
       assert.equal(rsp.ins[i].s, `0x${txn.inputs[i].s.toString('hex')}`);

--- a/test/txLib.js
+++ b/test/txLib.js
@@ -51,12 +51,18 @@ function checkParse(rsp, txn) {
       assert.equal(rsp.ins[i].s, `0x${txn.inputs[i].s.toString('hex')}`);
       assert.equal(rsp.ins[i].v, txn.inputs[i].v);
     } else if (txn.type === Type.SPEND_COND) {
-      assert.equal(rsp.ins[i].msgData, `0x${txn.inputs[i].msgData.toString('hex')}`);
-      assert.equal(rsp.ins[i].script, `0x${txn.inputs[i].script.toString('hex')}`);
+      if (i === 0) {
+        assert.equal(rsp.ins[i].msgData, `0x${txn.inputs[i].msgData.toString('hex')}`);
+        assert.equal(rsp.ins[i].script, `0x${txn.inputs[i].script.toString('hex')}`);
+      } else {
+        assert.equal(rsp.ins[i].r, `0x${txn.inputs[i].r.toString('hex')}`);
+        assert.equal(rsp.ins[i].s, `0x${txn.inputs[i].s.toString('hex')}`);
+        assert.equal(rsp.ins[i].v, txn.inputs[i].v);        
+      }
     } else {
       assert.equal(rsp.ins[i].r, EMPTY);
       assert.equal(rsp.ins[i].s, EMPTY);
-      assert.equal(toInt(rsp.ins[i].v), 0);
+      assert.equal(rsp.ins[i].v, 0);
     }
   }
   // outputs
@@ -269,16 +275,12 @@ contract('TxLib', (accounts) => {
             prevout: new Outpoint(prevTx, 0),
             script: '0x123456',
           }),
-          new Input({
-            prevout: new Outpoint(prevTx, 1),
-            script: '0x7890ab',
-          }),
+          new Input(new Outpoint(prevTx, 1)),
         ],[
           new Output(value / 2, alice, color),
           new Output(value / 2, bob, color),
-        ]);
+        ]).signAll(alicePriv);
         condition.inputs[0].setMsgData('0xabcdef');
-        condition.inputs[1].setMsgData('0xfedcba');
 
         const block = new Block(32);
         block.addTx(condition);


### PR DESCRIPTION
Resolves #184 

## Preface

The first input of a spending condition transaction is special.
It has two additional attributes:
- `script` with a bytecode of <accr title="spending condition">spendie</accr>
- `msgData` with a bytecode for msgData of a function call (called on spendie contract)

To account for that, we have a special code for parsing transaction ([contracts](https://github.com/leapdao/leap-contracts/blob/master/contracts/TxLib.sol#L69), [client](https://github.com/leapdao/leap-core/blob/c2c30fb2fe89da6a1d02744c6afd828a1acbc7c5/lib/input.js#L216).

## What was wrong

The thing is that it is only the first input of spendie is special, all the other inputs are the ordinary inputs and should be parsed as ordinary. That wasn't the case, solidity parser incorrectly tried to parse all the spendie inputs as the first one.

## The fix

- Use special parsing only for the first input of spendie [here](https://github.com/leapdao/leap-contracts/commit/a959bdc6ca59e971bff164bf701a31b5dc4ae864#diff-a4e8014fa0cb2ad3a5c650aa58b1883dR196)
- Use more realistic test data in tests [here](https://github.com/leapdao/leap-contracts/commit/a959bdc6ca59e971bff164bf701a31b5dc4ae864#diff-1675070299835c72d9963e9350b24a66R278). No script, no msgData for the rest of the inputs. Sign the tx. This change alone would make the tests fail because of incorrect parsing
- fix couple of errors in the unit tests making the test not working [here](https://github.com/leapdao/leap-contracts/pull/252/commits/30d9687776a136be869a0aaa629ee8e5a5a124b0) and [there](https://github.com/leapdao/leap-contracts/pull/252/commits/9eaae0b54a2c1e05ac2b6fd250caf1a752cdde4c).
- remove workaround from the integration tests: https://github.com/leapdao/integration-tests/pull/71
