### PR TITLE
fix(ci): broken integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 cache:
   - yarn
 node_js:
-  - '8.11'
+  - 10
 jobs:
   include:
     - stage: tests


### PR DESCRIPTION
nodejs 8.11 is deprecated on Travis