### PR TITLE
fix(tests): revert to use truffle compile with tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "LeapDAO bridge contracts (Plasma + PoS)",
   "main": "truffle-config.js",
   "scripts": {
-    "test": "scripts/test.sh",
+    "test": "truffle compile && scripts/test.sh",
     "clean": "rm -rf build/",
     "compile": "truffle compile",
     "deploy": "truffle migrate",


### PR DESCRIPTION
For some reason, `truffle test` is using the cache of `truffle compile` but is not caching
it's own compilation results. See https://github.com/leapdao/leap-contracts/pull/253#discussion_r362436902